### PR TITLE
fixed current_working_directory() to bypass static file links in path…

### DIFF
--- a/src/zupply.cpp
+++ b/src/zupply.cpp
@@ -11798,7 +11798,7 @@ namespace zz
 				return wstring_to_utf8(ret);
 			}
 #elif _GNU_SOURCE
-			char *buffer = get_current_dir_name();
+			char *buffer = realpath(".", nullptr);
 			if (buffer == nullptr)
 			{
 				// failed


### PR DESCRIPTION
… and return the real path

Fixes #6

get_current_dir_name() returns a path that follows symlinks which is different from all(?) other paths used in zupply. The difference created a problem where the relative paths returned for a file would contain multiple circuitous "../sameDirAgain" in a row. This fix replaces get_current_dir_name() with realpath() which circumvents symlinks.

This change did not break any more unittests than before (2 related to images are broken?)